### PR TITLE
Fix crash when remote .env value is missing

### DIFF
--- a/dist/env.js
+++ b/dist/env.js
@@ -77,7 +77,7 @@ const getEnvIssues = (env, isEnvMissing, isRemoteEnv, isInteractive = false, app
   setting === 'DB_USER' && (0, _utils.isEmpty)(env[setting]) || // Make sure there's a database defined
   setting === 'DB_DATABASE' && (0, _utils.isEmpty)(env[setting])); // Return the error if any
 
-  return (0, _utils.isEmpty)(missingSettings) ? '' : `${isRemoteEnv ? `Add the following ${missingSettings.length > 1 ? 'values' : 'value'} to the remote .env:\n${(0, _palette.colourNotice)(_path.default.join(sshAppPath, '.env'))}` : `Add the following ${missingSettings.length > 1 ? 'values' : 'value'} to your${isEnvMissing ? ` new` : ''} project .env:\n${(0, _palette.colourNotice)(_paths.pathLocalEnv)}`}\n\n${missingSettings.map(s => `${s}="${(0, _palette.colourNotice)(`value`)}"`).join('\n')}${isInteractive ? `\n\nThen hit [ enter ↵ ] to rerun this task` : ''}`;
+  return (0, _utils.isEmpty)(missingSettings) ? '' : `${isRemoteEnv ? `Add the following ${missingSettings.length > 1 ? 'values' : 'value'} to the remote .env:\n${(0, _palette.colourNotice)(_path.default.join(appPath, '.env'))}` : `Add the following ${missingSettings.length > 1 ? 'values' : 'value'} to your${isEnvMissing ? ` new` : ''} project .env:\n${(0, _palette.colourNotice)(_paths.pathLocalEnv)}`}\n\n${missingSettings.map(s => `${s}="${(0, _palette.colourNotice)(`value`)}"`).join('\n')}${isInteractive ? `\n\nThen hit [ enter ↵ ] to rerun this task` : ''}`;
 };
 
 exports.getEnvIssues = getEnvIssues;

--- a/src/env.js
+++ b/src/env.js
@@ -73,7 +73,7 @@ const getEnvIssues = (
               isRemoteEnv
                   ? `Add the following ${
                         missingSettings.length > 1 ? 'values' : 'value'
-                    } to the remote .env:\n${colourNotice(path.join(sshAppPath, '.env'))}`
+                    } to the remote .env:\n${colourNotice(path.join(appPath, '.env'))}`
                   : `Add the following ${
                         missingSettings.length > 1 ? 'values' : 'value'
                     } to your${


### PR DESCRIPTION
Swiff currently crashes when a value is missing from the server-side `.env` file (because of a misnamed variable).

This PR uses the correct variable name and thus prevents the crash.